### PR TITLE
Add support for smart writes, control user area and emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS += $(shell pkg-config libftdi1 --cflags)
-CFLAGS += -g -Wall
+CFLAGS += -g -Wall -std=c99
 #CFLAGS += -O2 -s
 LDFLAGS = $(shell pkg-config libftdi1 --libs)
 INCLUDES = 
@@ -10,8 +10,8 @@ TARGET = nrf24le1_flasher
 SRCS = \
 	src/hexfile.c \
 	src/main.c \
-	src/spi_ft232r.c
-
+        src/spi_ft232r.c 
+#	src/spi_emulator.c
 HEADERS = \
 	src/hexfile.h \
 	src/spi.h

--- a/src/hexfile.h
+++ b/src/hexfile.h
@@ -1,7 +1,7 @@
 #ifndef HEXFILE_H
 #define HEXFILE_H
 
-int hexfile_getline(FILE *fd, uint16_t *address, uint8_t *dest, size_t n);
+int hexfile_getline(FILE *fd, uint16_t *address, uint8_t *dest, size_t n, bool address_as_offset, uint16_t address_offset);
 
 #endif // HEXFILE_H
 

--- a/src/nrf_flash.h
+++ b/src/nrf_flash.h
@@ -1,0 +1,49 @@
+#ifndef NRF_FLASH_H
+#define NRF_FLASH_H
+
+// SPI Flash operations commands
+#define WREN 		0x06	// Set flash write enable latch
+#define WRDIS		0x04	// Reset flash write enable latch
+#define RDSR		0x05	// Read FLASH Status Register (FSR)
+#define WRSR		0x01	// Write FLASH Status Register (FSR)
+#define READ		0x03	// Read data from FLASH
+#define PROGRAM		0x02	// Write data to FLASH
+#define ERASE_PAGE	0x52	// Erase addressed page
+#define ERASE_ALL	0x62	// Erase all pages in FLASH main block and
+				// infopage
+#define RDFPCR		0x89	// Read FLASH Protect Configuration Register
+				// FPCR
+#define RDISMB		0x85	// Enable FLASH readback protection
+#define ENDEBUG		0x86	// Enable HW debug features
+
+// Flash Status Register (FSR) bits
+#define FSR_ENDEBUG	(1 << 7)	// Initial value read from byte ENDEBUG 
+					// in flash IP
+#define FSR_STP		(1 << 6)	// Enable code execution start from
+					// protected flash area (page address
+					// NUPP)
+#define FSR_WEN		(1 << 5)	// Flash write enable latch
+#define FSR_RDYN	(1 << 4)	// Flash ready flag, active low
+#define FSR_INFEN	(1 << 3)	// Flash IP Enable
+#define FSR_RDISMB	(1 << 2)	// Flash MB readback protection enabled,
+					// active low
+
+#define PAGE_SIZE	512
+#define PAGES_CNT	32
+
+#define FLASH_SIZE	(PAGE_SIZE * PAGES_CNT)
+
+#define CHIP_ID_SIZE    5
+#define CHIP_ID_OFFSET  0x0B
+#define NUPP_OFFSET	0x20
+
+#define USER_AREA_OFFSET 0x100
+
+struct infopage_config
+{
+    uint8_t tx_addr[5];
+    uint8_t channel;
+    uint8_t power;
+};
+
+#endif // NRF_FLASH_H

--- a/src/spi.h
+++ b/src/spi.h
@@ -4,6 +4,6 @@
 int spi_begin(uint8_t bus, uint8_t port);
 void spi_end();
 int spi_transfer(uint8_t *bytes, size_t size);
-
+int spi_transfer_sg(uint8_t op, uint16_t address, uint8_t *bytes, size_t size);
 
 #endif // SPI_H

--- a/src/spi_emulator.c
+++ b/src/spi_emulator.c
@@ -1,0 +1,85 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "spi.h"
+#include "nrf_flash.h"
+
+static uint8_t sfr = 0;
+
+static uint8_t memory[PAGE_SIZE * PAGES_CNT] = {0};
+static uint8_t ip[PAGE_SIZE] = {0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa , 0x80, 0x81, 0x82, 0x83, 0x84, 0};
+
+static void program(const uint16_t address, const size_t size, const uint8_t *data)
+{
+	uint8_t *ptr = sfr & FSR_INFEN ? ip : memory;
+	for (size_t i = 0; i < size; i++) {
+		ptr[address + i] = ptr[address + i] & data[i];
+	}
+}
+
+int spi_begin(uint8_t bus, uint8_t port)
+{
+	fprintf(stderr, "Warning! SPI EMULATOR is used, no operations with real NRF device are performed.\n");
+	return 0;
+}
+
+void spi_end()
+{
+	fprintf(stderr, "Warning! SPI EMULATOR is used, no operations with real NRF device are performed.\n");
+}
+
+int spi_transfer(uint8_t *bytes, size_t size)
+{
+    uint8_t *ptr = sfr & FSR_INFEN ? ip : memory;
+
+	switch (bytes[0])
+	{
+	case WREN:
+		sfr |= FSR_WEN;
+		break;
+	case WRSR:
+		sfr = bytes[1];
+		break;
+	case RDSR:
+		bytes[1] = sfr & ~FSR_RDYN;
+		break;
+	case ERASE_PAGE:
+        memset(&ptr[PAGE_SIZE * bytes[1]], 0xff, PAGE_SIZE);
+		break;
+	case ERASE_ALL:
+		memset(&memory[0], 0xff, sizeof(memory));
+		memset(&ip[0], 0xff, sizeof(ip));
+		break;
+	case PROGRAM:
+		program(bytes[1]<<8 | bytes[2], size - 3, &bytes[3]);
+		break;
+	case READ:
+        memcpy(bytes + 3, &ptr[(bytes[1]<<8 | bytes[2])], size - 3);
+		break;
+	default:
+		printf("Unknown command 0x%x\n", bytes[0]);
+	}
+
+	return size;
+}
+
+int spi_transfer_sg(uint8_t op, uint16_t address, uint8_t *bytes, size_t size)
+{
+	switch (op)
+	{
+	case PROGRAM:
+		program(address, size, bytes);
+		break;
+	case READ:
+		{
+            uint8_t *ptr = sfr & FSR_INFEN ? ip : memory;
+			memcpy(bytes, &ptr[address], size);
+		}
+		break;
+	}
+
+	return size;
+}


### PR DESCRIPTION
Smart write checks if erasing is necessary, thus life of flash
memory is extended.

To use emulator, compilation of spi_emulator.c instead of
spi_ft232r.c should be manually enabled in Makefile.